### PR TITLE
Implement modal improvements and custom prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,6 @@
 
     <div class="container mx-auto max-w-4xl p-4 md:p-8 flex-grow">
         
-        <div id="settings-modal" class="hidden ...">
-            </div>
 
         <div id="login-required-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 z-40 flex items-center justify-center p-4">
             <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-full max-w-sm text-center">
@@ -32,6 +30,35 @@
                 </div>
             </div>
         </div>
+
+        <div id="accept-terms-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 z-40 flex items-center justify-center p-4">
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-full max-w-sm text-center">
+                <h3 class="text-lg font-bold mb-2">Términos de Uso</h3>
+                <p class="text-sm mb-4">Debes aceptar nuestros <a href="legal/terms.html" class="underline text-blue-600">Términos de Uso</a> antes de continuar.</p>
+                <div class="flex justify-center gap-4">
+                    <button id="cancel-terms-btn" class="bg-gray-300 dark:bg-gray-600 text-gray-800 dark:text-gray-200 py-2 px-4 rounded-lg hover:bg-gray-400">Cancelar</button>
+                    <button id="accept-terms-btn" class="bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700">Aceptar</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="custom-prompt-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 z-40 flex items-center justify-center p-4">
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl w-full max-w-md">
+                <h3 class="text-xl font-bold mb-4">Prompt Personalizado</h3>
+                <textarea id="custom-prompt-input" rows="4" class="w-full p-2 border rounded mb-2 dark:bg-gray-700"></textarea>
+                <div class="flex items-center mb-4">
+                    <input type="checkbox" id="save-custom-prompt" class="mr-2">
+                    <label for="save-custom-prompt" class="text-sm">Guardar para después</label>
+                </div>
+                <div id="saved-prompts-list" class="space-y-1 mb-4"></div>
+                <div class="flex justify-end gap-4">
+                    <button id="cancel-custom-prompt" class="bg-gray-300 dark:bg-gray-600 text-gray-800 dark:text-gray-200 py-2 px-4 rounded-lg hover:bg-gray-400">Cancelar</button>
+                    <button id="confirm-custom-prompt" class="bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700">Usar</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="history-overlay" class="hidden fixed inset-0 bg-black bg-opacity-50 z-20"></div>
 
         </div>
 
@@ -88,6 +115,7 @@
                         <button type="button" data-action="simplify" class="action-btn text-sm bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 py-1 px-3 rounded-full">Simplificar</button>
                         <button type="button" data-action="summarize" class="action-btn text-sm bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 py-1 px-3 rounded-full">Resumir</button>
                         <button type="button" data-action="expand" class="action-btn text-sm bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 py-1 px-3 rounded-full">Expandir</button>
+                        <button type="button" data-action="custom" class="action-btn text-sm bg-purple-600 hover:bg-purple-700 text-white py-1 px-3 rounded-full">Personalizado</button>
                     </div>
                 </div>
             </form>

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -6,10 +6,17 @@
     <p><em>Última actualización: 7 de Junio de 2025</em></p>
 
     <h2>Uso del Servicio</h2>
-    <p>Al usar Correctia, aceptas no utilizar el servicio para actividades ilegales o para infringir los derechos de otros. El servicio se proporciona "tal cual", sin garantías de ningún tipo. Las correcciones y sugerencias son generadas por una IA y pueden contener errores.</p>
+    <ul>
+        <li>No utilices Correctia para actividades ilegales o que infrinjan derechos de terceros.</li>
+        <li>El servicio se ofrece "tal cual", sin garantías de ningún tipo.</li>
+        <li>Las correcciones provienen de un modelo de IA y pueden contener errores.</li>
+    </ul>
 
     <h2>Limitación de Responsabilidad</h2>
     <p>No nos hacemos responsables de ningún daño directo o indirecto que resulte del uso de nuestro servicio. Eres el único responsable de verificar la exactitud y adecuación del contenido generado.</p>
+
+    <h2>Servicios de Terceros</h2>
+    <p>Correctia utiliza la plataforma <strong>Puter</strong> para gestionar la autenticación de usuarios, el procesamiento de pagos y las llamadas a la IA. Puter es la responsable de dichas operaciones y de cualquier incidencia relacionada con ellas. Correctia no asume responsabilidad por fallos o pérdidas derivadas de estos servicios externos.</p>
 
     <p class="border-t border-gray-400 pt-4 mt-4 text-sm"><strong>Aviso:</strong> Este es un texto de ejemplo. Para un proyecto real, es fundamental que consultes a un profesional legal para redactar tus términos.</p>
 </div>


### PR DESCRIPTION
## Summary
- allow closing modals by clicking outside
- require accepting terms of use before sending text to the AI
- add custom prompt feature with storage of two prompts
- add overlay for history panel
- clarify Puter responsibilities in terms of use

## Testing
- `node --check js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_684804b4ca3883269c9711bf169c6362