### PR TITLE
Implement language detection and adjust history UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Correctia - Tu Asistente de Redacción IA</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://js.puter.com/v2/"></script>
+    <script src="https://cdn.jsdelivr.net/npm/franc@6.1.0/dist/franc.min.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 font-sans flex flex-col min-h-screen">
 
@@ -58,7 +59,7 @@
             </div>
         </div>
 
-        <div id="history-overlay" class="hidden fixed inset-0 bg-black bg-opacity-50 z-20"></div>
+        <div id="history-overlay" class="hidden fixed inset-0 bg-transparent z-20"></div>
 
         </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -114,7 +114,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    let currentLang = localStorage.getItem('lang') || 'es';
+    let currentLang = localStorage.getItem('lang');
+    if (!currentLang) {
+        const browserLang = navigator.language || (navigator.languages && navigator.languages[0]) || 'es';
+        const detected = typeof franc === 'function' ? franc(browserLang) : '';
+        if (detected === 'eng') currentLang = 'en';
+        else if (detected === 'spa') currentLang = 'es';
+        else currentLang = browserLang.startsWith('en') ? 'en' : 'es';
+    }
 
     const getT = (key) => TRANSLATIONS[currentLang][key];
 


### PR DESCRIPTION
## Summary
- use Franc to guess browser language at startup
- stop dimming the page when opening the history

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a63776a0832691aebf5acc9c41d4