### PR TITLE
Add theme selection and bigger logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,14 @@
                         <option value="en">English</option>
                     </select>
                 </div>
+                <div class="flex items-center justify-between mb-4">
+                    <label id="theme-label" for="theme-select" class="text-gray-800 dark:text-gray-200">Tema</label>
+                    <select id="theme-select" class="bg-gray-200 dark:bg-gray-700 rounded px-2 py-1">
+                        <option id="theme-default-option" value="default">Predeterminado</option>
+                        <option id="theme-light-option" value="light">Claro</option>
+                        <option id="theme-dark-option" value="dark">Oscuro</option>
+                    </select>
+                </div>
                 <button id="feedback-btn" class="mb-2 w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded-lg">Ofrecer comentarios</button>
                 <button id="close-settings" class="mt-2 w-full bg-gray-200 dark:bg-gray-600 py-2 rounded-lg">Cerrar</button>
             </div>
@@ -115,7 +123,7 @@
         </aside>
 
         <header class="text-center mb-8 pt-12">
-            <h1 class="text-4xl md:text-5xl font-bold text-blue-600 dark:text-blue-400"><img src="images/correctia-logo.png" alt="Correctia — Redacción con IA" class="mx-auto w-40 md:w-48 h-auto"></h1>
+              <h1 class="flex items-center justify-center text-4xl md:text-5xl font-bold text-blue-600 dark:text-blue-400"><img src="images/correctia-logo.png" alt="Correctia — Redacción con IA" class="w-56 md:w-64 h-auto"><span class="ml-2 text-4xl md:text-5xl">🚀</span></h1>
             <p id="header-subtitle" class="text-lg text-gray-600 dark:text-gray-400 mt-2">Tu navaja suiza de redacción con IA.</p>
         </header>
 

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,10 @@ document.addEventListener('DOMContentLoaded', () => {
             settings: 'Ajustes',
             closeSettings: 'Cerrar',
             languageLabel: 'Idioma',
+            themeLabel: "Tema",
+            themeDefault: "Predeterminado",
+            themeLight: "Claro",
+            themeDark: "Oscuro",
             loginRequiredTitle: 'Inicio de Sesión Requerido',
             loginRequiredText: 'Para usar esta función, necesitas iniciar sesión. Serás redirigido a Puter para autenticarte de forma segura.',
             loginRequiredQuestion: '¿Deseas continuar?',
@@ -63,6 +67,10 @@ document.addEventListener('DOMContentLoaded', () => {
             settings: 'Settings',
             closeSettings: 'Close',
             languageLabel: 'Language',
+            themeLabel: "Theme",
+            themeDefault: "Default",
+            themeLight: "Light",
+            themeDark: "Dark",
             loginRequiredTitle: 'Login Required',
             loginRequiredText: 'To use this feature you must sign in. You will be redirected to Puter for secure authentication.',
             loginRequiredQuestion: 'Continue?',
@@ -135,6 +143,10 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('settings-title').innerText = t.settings;
         document.getElementById('close-settings').innerText = t.closeSettings;
         document.getElementById('language-label').innerText = t.languageLabel;
+        document.getElementById("theme-label").innerText = t.themeLabel;
+        document.getElementById("theme-default-option").innerText = t.themeDefault;
+        document.getElementById("theme-light-option").innerText = t.themeLight;
+        document.getElementById("theme-dark-option").innerText = t.themeDark;
         document.getElementById('login-required-title').innerText = t.loginRequiredTitle;
         document.getElementById('login-required-text').innerText = t.loginRequiredText;
         document.getElementById('login-required-question').innerText = t.loginRequiredQuestion;
@@ -426,11 +438,31 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
+    const applyTheme = (theme) => {
+        if (theme === "dark") {
+            document.documentElement.classList.add("dark");
+            document.body.style.backgroundColor = "#1f2937";
+        } else if (theme === "light") {
+            document.documentElement.classList.remove("dark");
+            document.body.style.backgroundColor = "#f8fafc";
+        } else {
+            document.documentElement.classList.remove("dark");
+            document.body.style.backgroundColor = "";
+        }
+    };
     // --- APP INITIALIZATION ---
     async function initializeApp() {
         applyTranslations();
         const languageSelect = document.getElementById('language-select');
         languageSelect.value = currentLang;
+        const themeSelect = document.getElementById("theme-select");
+        themeSelect.value = localStorage.getItem("theme") || "default";
+        applyTheme(themeSelect.value);
+        themeSelect.addEventListener("change", () => {
+            const th = themeSelect.value;
+            localStorage.setItem("theme", th);
+            applyTheme(th);
+        });
         languageSelect.addEventListener('change', () => {
             currentLang = languageSelect.value;
             localStorage.setItem('lang', currentLang);


### PR DESCRIPTION
## Summary
- enlarge logo and add a rocket emoji
- add theme selector in settings modal
- implement theme persistence with localStorage
- update translations

## Testing
- `node -e "console.log('Node test')"`

------
https://chatgpt.com/codex/tasks/task_e_684a030255748326ae77cce7b33e2869