### PR TITLE
Fix menu button toggle and adjust hint styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
 
         <div id="articles-hint" class="hidden fixed top-16 right-48 bg-yellow-200 border border-yellow-400 text-yellow-900 px-3 py-2 rounded shadow-lg">
             <span id="articles-hint-text">Genera artículos profesionales con IA desde aquí</span>
-            <span class="absolute -right-4 top-1/2 transform -translate-y-1/2 text-2xl">⬅️</span>
+            <span class="absolute -right-3 top-1/2 transform -translate-y-1/2 text-xl">←</span>
         </div>
         
         <div id="settings-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-30 flex items-center justify-center">

--- a/js/main.js
+++ b/js/main.js
@@ -514,6 +514,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 navOverlay.classList.add('hidden');
                 menuItems.classList.add('hidden');
                 userAuthArea.classList.remove('hidden');
+                menuToggleBtn.classList.remove('hidden');
             });
             historyList.appendChild(div);
         });
@@ -600,21 +601,23 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         historyToggle.addEventListener('click', () => {
-            historyPanel.classList.toggle('hidden');
-            historyPanel.classList.toggle('translate-x-full');
-            historyOverlay.classList.toggle('hidden');
-            userAuthArea.classList.toggle('hidden');
-            navMenu.classList.toggle("hidden");
-            navOverlay.classList.add('hidden');
-            menuItems.classList.add('hidden');
+        historyPanel.classList.toggle('hidden');
+        historyPanel.classList.toggle('translate-x-full');
+        historyOverlay.classList.toggle('hidden');
+        userAuthArea.classList.toggle('hidden');
+        navMenu.classList.toggle("hidden");
+        navOverlay.classList.add('hidden');
+        menuItems.classList.add('hidden');
+        menuToggleBtn.classList.remove('hidden');
         });
         historyOverlay.addEventListener('click', () => {
-            historyPanel.classList.add('hidden', 'translate-x-full');
-            historyOverlay.classList.add('hidden');
-            navMenu.classList.remove("hidden");
-            navOverlay.classList.add('hidden');
-            menuItems.classList.add('hidden');
-            userAuthArea.classList.remove('hidden');
+        historyPanel.classList.add('hidden', 'translate-x-full');
+        historyOverlay.classList.add('hidden');
+        navMenu.classList.remove("hidden");
+        navOverlay.classList.add('hidden');
+        menuItems.classList.add('hidden');
+        userAuthArea.classList.remove('hidden');
+        menuToggleBtn.classList.remove('hidden');
         });
 
         clearHistoryBtn.addEventListener('click', clearHistory);


### PR DESCRIPTION
## Summary
- keep the navigation menu button visible after closing the history panel
- tweak the hint for the articles tool: use a minimal arrow and adjust positioning

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e8e41b60c8326999af026cbdf1960